### PR TITLE
Improvements in vulnerability checking

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,15 @@
+---
+
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule: 
+      interval: "daily"
+  
+  - package-ecosystem: "gomod"
+    directory: "src/jetstream/"
+    schedule:
+      interval: "daily"
+    

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,6 +8,16 @@ updates:
     schedule: 
       interval: "daily"
   
+  - package-ecosystem: "npm"
+    directory: "/electron"
+    schedule: 
+      interval: "daily"
+  
+  - package-ecosystem: "npm"
+    directory: "/website"
+    schedule: 
+      interval: "daily"
+  
   - package-ecosystem: "gomod"
     directory: "src/jetstream/"
     schedule:

--- a/build/bk-build.sh
+++ b/build/bk-build.sh
@@ -34,7 +34,7 @@ go env
 
 # Need to install swag in both cases
 echo "Generating OpenAPI documentation..."
-go get github.com/swaggo/swag/cmd/swag@v1.6.7
+go install github.com/swaggo/swag/cmd/swag@v1.6.7
 swag init
 
 if [ "${ACTION}" == "build" ]; then

--- a/src/jetstream/go.mod
+++ b/src/jetstream/go.mod
@@ -92,6 +92,8 @@ replace github.com/cloudfoundry-incubator/stratos/src/jetstream/plugins/kubernet
 
 replace github.com/cloudfoundry-incubator/stratos/src/jetstream/plugins/monocular => ./plugins/monocular
 
+replace github.com/cloudfoundry-incubator/stratos/src/jetstream/docs => ./docs
+
 replace (
 	github.com/SermoDigital/jose => github.com/SermoDigital/jose v0.9.2-0.20180104203859-803625baeddc
 	github.com/Sirupsen/logrus => github.com/sirupsen/logrus v1.4.1


### PR DESCRIPTION
This PR fixes the backend manual build in order allow for `govulncheck` to run and enable manual vulnerability checking.
It also introduces a dependabot base config to check for vulnerabilites automatically, at a rate of once per day.