### PR TITLE
Fix database migrations by casting dialect correctly

### DIFF
--- a/src/jetstream/datastore/20170818120003_InitialSchema.go
+++ b/src/jetstream/datastore/20170818120003_InitialSchema.go
@@ -15,7 +15,7 @@ func Up20170818120003(txn *sql.Tx) error {
 
 	binaryDataType := "BYTEA"
 
-	if _, ok := dialect.(goose.MySQLDialect); ok {
+	if _, ok := dialect.(*goose.MySQLDialect); ok {
 		binaryDataType = "BLOB"
 	}
 
@@ -28,7 +28,7 @@ func Up20170818120003(txn *sql.Tx) error {
 	createTokens += "token_expiry  BIGINT      NOT NULL, "
 	createTokens += "last_updated  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP)"
 
-	if _, ok := dialect.(goose.PostgresDialect); ok {
+	if _, ok := dialect.(*goose.PostgresDialect); ok {
 		createTokens += " WITH (OIDS=FALSE);"
 	} else {
 		createTokens += ";"

--- a/src/jetstream/datastore/20170818162837_SetupSchema.go
+++ b/src/jetstream/datastore/20170818162837_SetupSchema.go
@@ -28,7 +28,7 @@ func Up20170818162837(txn *sql.Tx) error {
 	}
 
 	// Find a way to ensure this in Mysql
-	if _, ok := dialect.(goose.PostgresDialect); ok {
+	if _, ok := dialect.(*goose.PostgresDialect); ok {
 		createIndex := "CREATE UNIQUE INDEX console_config_one_row"
 		createIndex += "  ON console_config((uaa_endpoint IS NOT NULL));"
 		_, err = txn.Exec(createIndex)

--- a/src/jetstream/datastore/20180413135700_MetricsSchema.go
+++ b/src/jetstream/datastore/20180413135700_MetricsSchema.go
@@ -13,13 +13,13 @@ func init() {
 func Up20180413135700(txn *sql.Tx) error {
 	dialect := goose.GetDialect()
 
-	if _, ok := dialect.(goose.Sqlite3Dialect); ok {
+	if _, ok := dialect.(*goose.Sqlite3Dialect); ok {
 		// SQLite does not support MODIFY on ALTER TABLE - but fortunately it doesn't mind about the column sizes
 		return nil
 	}
 
 	// Special case Postgres as it has different syntax
-	if _, ok := dialect.(goose.PostgresDialect); ok {
+	if _, ok := dialect.(*goose.PostgresDialect); ok {
 		alterColumn := "ALTER TABLE cnsis ALTER COLUMN cnsi_type TYPE VARCHAR(16), ALTER COLUMN cnsi_type SET NOT NULL"
 		_, err := txn.Exec(alterColumn)
 		if err != nil {

--- a/src/jetstream/datastore/20180703142800_CFClient.go
+++ b/src/jetstream/datastore/20180703142800_CFClient.go
@@ -15,7 +15,7 @@ func Up20180703142800(txn *sql.Tx) error {
 
 	binaryDataType := "BYTEA"
 
-	if _, ok := dialect.(goose.MySQLDialect); ok {
+	if _, ok := dialect.(*goose.MySQLDialect); ok {
 		binaryDataType = "BLOB"
 	}
 

--- a/src/jetstream/datastore/20190522121200_LocalUsers.go
+++ b/src/jetstream/datastore/20190522121200_LocalUsers.go
@@ -20,7 +20,7 @@ func Up20190522121200(txn *sql.Tx) error {
 
 	binaryDataType := "BYTEA"
 
-	if _, ok := dialect.(goose.MySQLDialect); ok {
+	if _, ok := dialect.(*goose.MySQLDialect); ok {
 		binaryDataType = "BLOB"
 	}
 
@@ -42,7 +42,7 @@ func Up20190522121200(txn *sql.Tx) error {
 	createLocalUsers += "PRIMARY KEY (user_guid) )"
 
 	//Configure Postgres migration options
-	if _, ok := dialect.(goose.PostgresDialect); ok {
+	if _, ok := dialect.(*goose.PostgresDialect); ok {
 		createLocalUsers += " WITH (OIDS=FALSE);"
 	} else {
 		createLocalUsers += ";"

--- a/src/jetstream/datastore/20190930092500_LocalUsersTriggerFix.go
+++ b/src/jetstream/datastore/20190930092500_LocalUsersTriggerFix.go
@@ -15,15 +15,15 @@ func Up20190930092500(txn *sql.Tx) error {
 
 	var dropTrigger string
 
-	if _, ok := dialect.(goose.Sqlite3Dialect); ok {
+	if _, ok := dialect.(*goose.Sqlite3Dialect); ok {
 		//SQLITE
 		dropTrigger = "DROP TRIGGER IF EXISTS update_last_updated;"
 	}
 
-	if _, ok := dialect.(goose.PostgresDialect); ok {
+	if _, ok := dialect.(*goose.PostgresDialect); ok {
 		// POSTGRESQL
 		dropTrigger = "DROP TRIGGER IF EXISTS update_trigger ON local_users;"
-	} else if _, ok := dialect.(goose.MySQLDialect); ok {
+	} else if _, ok := dialect.(*goose.MySQLDialect); ok {
 		// MYSQL
 		dropTrigger = "DROP TRIGGER IF EXISTS update_last_updated;"
 		// Ignore error - most likely permission bug issue on Mysql

--- a/src/jetstream/datastore/20191008121900_PrimaryKeys.go
+++ b/src/jetstream/datastore/20191008121900_PrimaryKeys.go
@@ -20,7 +20,7 @@ func Up20191008121900(txn *sql.Tx) error {
 	}
 
 	// Note: SQLite does not allow constraints to be added after table creation
-	if _, ok := dialect.(goose.Sqlite3Dialect); ok {
+	if _, ok := dialect.(*goose.Sqlite3Dialect); ok {
 		return nil
 	}
 

--- a/src/jetstream/plugins/analysis/20200210105400_Analysis.go
+++ b/src/jetstream/plugins/analysis/20200210105400_Analysis.go
@@ -21,7 +21,7 @@ func Up20200210105400(txn *sql.Tx) error {
 
 	// `user` is a reserved keyword in postgres. For other DBs the column is renamed into
 	// `user_guid` in a subsequent `20201102132553_RenameUserColumn` migration
-	if _, ok := dialect.(goose.PostgresDialect); ok {
+	if _, ok := dialect.(*goose.PostgresDialect); ok {
 		createAnalysisTabls += "user_guid      VARCHAR(36) NOT NULL,"
 	} else {
 		createAnalysisTabls += "user           VARCHAR(36) NOT NULL,"

--- a/src/jetstream/plugins/analysis/20201005105400_AnalysisUpstream.go
+++ b/src/jetstream/plugins/analysis/20201005105400_AnalysisUpstream.go
@@ -20,7 +20,7 @@ func Up20201005105400(txn *sql.Tx) error {
 
 	// `user` is a reserved word in postgres. For other DBs the column is renamed into
 	// `user_guid` in a subsequent `20201102132553_RenameUserColumn` migration
-	if _, ok := dialect.(goose.PostgresDialect); ok {
+	if _, ok := dialect.(*goose.PostgresDialect); ok {
 		createAnalysisTabls += "user_guid      VARCHAR(36) NOT NULL,"
 	} else {
 		createAnalysisTabls += "user           VARCHAR(36) NOT NULL,"

--- a/src/jetstream/plugins/analysis/20201102132553_RenameUserColumn.go
+++ b/src/jetstream/plugins/analysis/20201102132553_RenameUserColumn.go
@@ -15,13 +15,13 @@ func Up20201102132553(txn *sql.Tx) error {
 
 	// `user` is a reserved keyword in postgres, so for postgres the column
 	// was created as `user_guid` from the beginning -- skipping this migration.
-	if _, ok := dialect.(goose.PostgresDialect); ok {
+	if _, ok := dialect.(*goose.PostgresDialect); ok {
 		return nil
 	}
 
 	var renameQuery string
 
-	if _, ok := dialect.(goose.MySQLDialect); ok {
+	if _, ok := dialect.(*goose.MySQLDialect); ok {
 		renameQuery = `ALTER TABLE analysis CHANGE COLUMN user user_guid VARCHAR(36) NOT NULL`
 	} else {
 		renameQuery = `ALTER TABLE analysis RENAME user TO user_guid`

--- a/src/jetstream/plugins/monocular/20190307115300_ChartStore.go
+++ b/src/jetstream/plugins/monocular/20190307115300_ChartStore.go
@@ -34,7 +34,7 @@ func Up20190307115301(txn *sql.Tx) error {
 	}
 
 	binaryDataType := "BYTEA"
-	if _, ok := dialect.(goose.MySQLDialect); ok {
+	if _, ok := dialect.(*goose.MySQLDialect); ok {
 		binaryDataType = "BLOB"
 	}
 

--- a/src/jetstream/setup_console_test.go
+++ b/src/jetstream/setup_console_test.go
@@ -14,7 +14,7 @@ func TestConsoleSetup(t *testing.T) {
 
 	Convey("Check that we can migrate data from the old console_config table", t, func() {
 
-		db, _, err := datastore.GetInMemorySQLLiteConnection()
+		db, err := datastore.GetInMemorySQLLiteConnection()
 		if err != nil {
 			t.Errorf("can not open sqlite database for testing: %v", err)
 		}


### PR DESCRIPTION
The dialect cast was introduced as a regular struct cast. This will never succeed, since the dialect returned is a pointer to a struct, and since we rely on the cast being successful to detect the dialect to apply the correct SQL statements inside the migrations, this made the migrations fail.